### PR TITLE
Build with openmp enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -197,6 +197,7 @@ version = "0.1.6"
 dependencies = [
  "cc",
  "criterion",
+ "openmp-sys",
 ]
 
 [[package]]
@@ -304,6 +305,15 @@ name = "oorandom"
 version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+
+[[package]]
+name = "openmp-sys"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6309d417983bf3e5155416f38ed21822bb9b25210c148b4f14155bd1d42397a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "plotters"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+openmp-sys = "1.2"
 
 [build-dependencies]
 cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .flag("-std=c++11")
+        .flag("-fopenmp")
         .file("src/esaxx.cpp")
         .include("src")
         .compile("esaxx");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@
 //! assert_eq!(iter.next(), None);
 //! ```
 
+extern crate openmp_sys;
+
 use std::convert::TryInto;
 mod esa;
 mod sais;


### PR DESCRIPTION
I wonder why rust esaxx is not building with openmp enabled, is it because of bench results?

Bench results for esaxx after compiling with openmp:
```
     Running unittests (target/release/deps/bench_suffix-df0a878f2b8a88c5)
Benchmarking suffix_cpp_short: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 9.9s, or reduce sample count to 50.
suffix_cpp_short        time:   [96.054 ms 101.24 ms 106.33 ms]
                        change: [+1875.8% +1977.7% +2080.7%] (p = 0.00 < 0.05)
                        Performance has regressed.

suffix_rust_short       time:   [17.435 ms 17.714 ms 18.017 ms]
                        change: [+1.2737% +3.2344% +5.2335%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high mild

Benchmarking suffix_cpp_long: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 17.9s, or reduce sample count to 20.
suffix_cpp_long         time:   [191.65 ms 198.07 ms 204.15 ms]
                        change: [+274.91% +287.44% +299.12%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 24 outliers among 100 measurements (24.00%)
  18 (18.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild

Benchmarking suffix_rust_long: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 8.3s, or reduce sample count to 60.
suffix_rust_long        time:   [82.414 ms 83.090 ms 83.802 ms]
                        change: [+0.5142% +1.5211% +2.4515%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
```

Bench results for tokenizers (looks like improved):

```
     Running unittests (target/release/deps/bert_benchmark-36a6484a39fc6fc3)

WordPiece BERT encode   time:   [32.111 us 32.259 us 32.417 us]
                        change: [-2.1587% -1.3190% -0.3945%] (p = 0.01 < 0.05)
                        Change within noise threshold.

WordPiece BERT encode batch
                        time:   [5.6506 ms 5.7437 ms 5.8805 ms]
                        change: [-1.3381% +2.6752% +7.7356%] (p = 0.28 > 0.05)
                        No change in performance detected.
Found 2 outliers among 20 measurements (10.00%)
  1 (5.00%) high mild
  1 (5.00%) high severe

WordPiece Train vocabulary (small)
                        time:   [66.828 ms 69.333 ms 71.543 ms]
                        change: [-7.2426% -4.1033% -0.8811%] (p = 0.04 < 0.05)
                        Change within noise threshold.

Benchmarking WordPiece Train vocabulary (big): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 22.2s.
WordPiece Train vocabulary (big)
                        time:   [2.3391 s 2.4422 s 2.5561 s]
                        change: [-1.9998% +3.8469% +10.330%] (p = 0.23 > 0.05)
                        No change in performance detected.

     Running unittests (target/release/deps/bpe_benchmark-8e45288a8909865c)

BPE GPT2 encode         time:   [21.985 us 22.402 us 22.865 us]
                        change: [-3.2493% -1.5150% +0.3195%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 2 outliers among 20 measurements (10.00%)
  2 (10.00%) high mild

BPE GPT2 encode batch   time:   [8.1855 ms 8.3462 ms 8.5591 ms]
                        change: [-11.495% -7.5621% -3.6637%] (p = 0.00 < 0.05)
                        Performance has improved.

BPE GPT2 encode, no cache
                        time:   [40.990 us 41.592 us 42.242 us]
                        change: [-6.9280% -4.8677% -3.0182%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild

BPE GPT2 encode batch, no cache
                        time:   [6.9638 ms 7.3647 ms 7.8089 ms]
                        change: [-5.8805% -0.4388% +4.9162%] (p = 0.88 > 0.05)
                        No change in performance detected.
Found 1 outliers among 20 measurements (5.00%)
  1 (5.00%) high mild

BPE Train vocabulary (small)
                        time:   [63.990 ms 68.226 ms 74.532 ms]
                        change: [-1.4449% +4.7177% +11.094%] (p = 0.18 > 0.05)
                        No change in performance detected.

Benchmarking BPE Train vocabulary (big): Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 22.5s.
BPE Train vocabulary (big)
                        time:   [2.2638 s 2.3047 s 2.3518 s]
                        change: [-2.3220% +0.0703% +2.7694%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high mild
```