### PR TITLE
Fix ignoring unknown option -std=c++11 warning

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,9 @@
 #[cfg(feature = "cpp")]
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "macos", target_env = "msvc")))]
 fn main() {
     cc::Build::new()
         .cpp(true)
         .flag("-std=c++11")
-        .static_crt(true)
         .file("src/esaxx.cpp")
         .include("src")
         .compile("esaxx");
@@ -17,6 +16,16 @@ fn main() {
         .cpp(true)
         .flag("-std=c++11")
         .flag("-stdlib=libc++")
+        .file("src/esaxx.cpp")
+        .include("src")
+        .compile("esaxx");
+}
+
+#[cfg(feature = "cpp")]
+#[cfg(target_env = "msvc")]
+fn main() {
+    cc::Build::new()
+        .cpp(true)
         .static_crt(true)
         .file("src/esaxx.cpp")
         .include("src")


### PR DESCRIPTION
MSVC doesn't recognize the `-std=c++11` flag, and cargo reports this warning:
```
warning: esaxx-rs@0.1.10: cl : Command line warning D9002 : ignoring unknown option '-std=c++11'
```

This PR updates `build.rs` so that it doesn't set the flag with MSVC. Additionally, since `static_crt` only works with MSVC (see also [documentation](https://docs.rs/cc/1.0.97/cc/struct.Build.html#method.static_crt)), this PR removes it from the other environments.