### PR TITLE
Expanding platform support: Add Windows and Linux cross-compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,22 +1,59 @@
 #[cfg(feature = "cpp")]
-#[cfg(not(target_os = "macos"))]
 fn main() {
-    cc::Build::new()
-        .cpp(true)
-        .flag("-std=c++11")
-        .static_crt(true)
-        .file("src/esaxx.cpp")
-        .include("src")
-        .compile("esaxx");
-}
+    let target = std::env::var("TARGET").unwrap_or_default();
 
-#[cfg(feature = "cpp")]
-#[cfg(target_os = "macos")]
-fn main() {
+    // For Windows GNU targets
+    if target.contains("windows-gnu") {
+        cc::Build::new()
+            .cpp(true)
+            .flag("-std=c++11")
+            // No -stdlib=libc++ for Windows GNU
+            .static_crt(true)
+            .file("src/esaxx.cpp")
+            .include("src")
+            .compile("esaxx");
+
+        return;
+    }
+
+    // For Windows MSVC targets
+    if target.contains("windows-msvc") {
+        let mut build = cc::Build::new();
+        build
+            .cpp(true)
+            .static_crt(true)
+            .file("src/esaxx.cpp")
+            .include("src");
+
+        // Enable exceptions for MSVC builds
+        // MSVC-style flags
+        build.flag("/EHsc");
+
+        // Also try GCC-style flags as fallback for clang-cl
+        build.flag_if_supported("-fexceptions");
+        build.compile("esaxx");
+        return;
+    }
+
+    // For macOS targets
+    if target.contains("apple") {
+        cc::Build::new()
+            .cpp(true)
+            .flag("-std=c++11")
+            .flag("-stdlib=libc++")
+            .static_crt(true)
+            .file("src/esaxx.cpp")
+            .include("src")
+            .compile("esaxx");
+
+        return;
+    }
+
+    // For other targets (Linux, etc.)
     cc::Build::new()
         .cpp(true)
         .flag("-std=c++11")
-        .flag("-stdlib=libc++")
+        // No -stdlib=libc++ for other platforms
         .static_crt(true)
         .file("src/esaxx.cpp")
         .include("src")


### PR DESCRIPTION
This PR enhances the build script to reliably support cross-compilation across multiple platforms, addressing pain points I encountered while trying to use this library in a cross-platform project.

Changes:
- Fix Windows GNU builds by removing the incompatible `-stdlib=libc++` flag
- Support Windows MSVC builds via `cargo-xwin` by properly enabling C++ exceptions
- Maintain the existing macOS builds
- Ensure correct settings for Linux builds
- Correctly builds on macOS M* series for linux x86 via `cargo-zigbuild`

All changes are confined to the build script.
