### PR TITLE
Fix: Use dynamic C runtime (MD) for Windows MSVC compatibility

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,7 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .flag("-std=c++11")
-        .static_crt(true)
+        .static_crt(false)  // Use dynamic runtime to match ort_sys
         .file("src/esaxx.cpp")
         .include("src")
         .compile("esaxx");
@@ -17,7 +17,7 @@ fn main() {
         .cpp(true)
         .flag("-std=c++11")
         .flag("-stdlib=libc++")
-        .static_crt(true)
+        .static_crt(false)  // Use dynamic runtime to match ort_sys
         .file("src/esaxx.cpp")
         .include("src")
         .compile("esaxx");


### PR DESCRIPTION
## Problem

When building `esaxx-rs` with `.static_crt(true)`, it uses the static C runtime library (`/MT`), which causes linker errors when linking with other crates that use the dynamic runtime (`/MD`).

This is particularly problematic with crates like `ort` (ONNX Runtime bindings), which uses prebuilt binaries compiled with dynamic runtime.

**Error:**


## Solution

Change `.static_crt(true)` to `.static_crt(false)` in both Windows and macOS build configurations to use the dynamic C runtime (`/MD`), which is the standard for most Rust/Windows projects.

## Testing

✅ Tested on Windows 10 with MSVC toolchain  
✅ Tested with `ort` crate (ONNX Runtime v2.0.0-rc.10)  
✅ All integration tests pass  
✅ No linker errors  
✅ Compatible with downstream dependencies using dynamic runtime

## Impact

This change makes `esaxx-rs` compatible with the wider Rust ecosystem on Windows, particularly machine learning crates that depend on C++ libraries with dynamic runtime (ONNX Runtime, TensorFlow, PyTorch, etc.).