### PR TITLE
Don't force crt_static in build.rs so that Cargo can set it automatically

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -4,7 +4,6 @@ fn main() {
     cc::Build::new()
         .cpp(true)
         .flag("-std=c++11")
-        .static_crt(true)
         .file("src/esaxx.cpp")
         .include("src")
         .compile("esaxx");
@@ -17,7 +16,6 @@ fn main() {
         .cpp(true)
         .flag("-std=c++11")
         .flag("-stdlib=libc++")
-        .static_crt(true)
         .file("src/esaxx.cpp")
         .include("src")
         .compile("esaxx");


### PR DESCRIPTION
Currently, essax-rs tells the cc crate to force the use of a static C runtime. Setting this flag manually isn't actually necessary, the Rust ecosystem will automatically determine which C runtime to use. In fact, setting the flag really does nothing but break builds for people using a dynamic C runtime, such as user of the ort crate, so it should be removed.